### PR TITLE
WebApp: improved rerouting to start page

### DIFF
--- a/OnlineHealthCenter/WebApps/OnlineHealthCenterSPA/src/app/app-routing.module.ts
+++ b/OnlineHealthCenter/WebApps/OnlineHealthCenterSPA/src/app/app-routing.module.ts
@@ -1,11 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-const routes: Routes = [{ path: 'appointments', loadChildren: () => import('./appointments/appointments.module').then(m => m.AppointmentsModule) },
- { path: 'impressions', loadChildren: () => import('./impressions/impressions.module').then(m => m.ImpressionsModule) },
- { path: 'start-page', loadChildren: () => import('./employee-information/employee-information.module').then(m => m.EmployeeInformationModule) },
- { path: 'identity', loadChildren: () => import('./identity/identity.module').then(m => m.IdentityModule) },
- { path: 'reports', loadChildren: () => import('./reports/reports.module').then(m => m.ReportsModule) }
+const routes: Routes = [
+  { path: '', redirectTo: 'start-page', pathMatch: 'full' },
+  { path: 'appointments', loadChildren: () => import('./appointments/appointments.module').then(m => m.AppointmentsModule) },
+  { path: 'impressions', loadChildren: () => import('./impressions/impressions.module').then(m => m.ImpressionsModule) },
+  { path: 'start-page', loadChildren: () => import('./employee-information/employee-information.module').then(m => m.EmployeeInformationModule) },
+  { path: 'identity', loadChildren: () => import('./identity/identity.module').then(m => m.IdentityModule) },
+  { path: 'reports', loadChildren: () => import('./reports/reports.module').then(m => m.ReportsModule) }
 ];
 
 @NgModule({

--- a/OnlineHealthCenter/WebApps/OnlineHealthCenterSPA/src/app/app.component.ts
+++ b/OnlineHealthCenter/WebApps/OnlineHealthCenterSPA/src/app/app.component.ts
@@ -8,11 +8,4 @@ import { Router } from '@angular/router';
 })
 export class AppComponent {
   title = 'SPA';
-
-  constructor(private router: Router) {
-    const currentPath = this.router.url;
-    if (currentPath === '') {
-      this.router.navigateByUrl('/start-page');
-    }
-  }
 }

--- a/OnlineHealthCenter/WebApps/OnlineHealthCenterSPA/src/app/app.component.ts
+++ b/OnlineHealthCenter/WebApps/OnlineHealthCenterSPA/src/app/app.component.ts
@@ -9,9 +9,10 @@ import { Router } from '@angular/router';
 export class AppComponent {
   title = 'SPA';
 
-  private firstTime = true;
-  constructor(private router: Router)
-  {
-      this.router.navigate(['/start-page']);
+  constructor(private router: Router) {
+    const currentPath = this.router.url;
+    if (currentPath === '') {
+      this.router.navigateByUrl('/start-page');
+    }
   }
 }


### PR DESCRIPTION
- Implemented redirecting to `/start-page` if the current route is empty
- This change ensures that the app redirects to `/start-page` when starting the app and stays on the current page when reloading

Closes #167 